### PR TITLE
Use fraction-plugin 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </scm>
 
   <properties>
-    <version.swarm.fraction-plugin>15</version.swarm.fraction-plugin>
+    <version.swarm.fraction-plugin>16</version.swarm.fraction-plugin>
 
     <version.maven.plugin.api>3.2.5</version.maven.plugin.api>
     <version.maven-plugin-plugin>3.4</version.maven-plugin-plugin>


### PR DESCRIPTION
This should fix the issues with -swarm PR validation on CI, since the
new version of the plugin won't need to try and convert from
ArtifactRepository to RemoteRepository.

Doing this as a PR to test that theory.