### PR TITLE
SWARM-434: Support executable jars

### DIFF
--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -77,6 +77,7 @@ public class PackageTask extends DefaultTask {
                 .mainClass(ext.getMainClassName())
                 .bundleDependencies(ext.getBundleDependencies())
                 .executable(ext.getExecutable())
+                .executableScript(ext.getExecutableScript())
                 .properties(ext.getProperties())
                 .properties(fromFile)
                 .properties(PropertiesUtil.filteredSystemProperties(ext.getProperties(), false))

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/PackageTask.java
@@ -76,6 +76,7 @@ public class PackageTask extends DefaultTask {
                                  jarTask.getExtension(), jarTask.getArchivePath())
                 .mainClass(ext.getMainClassName())
                 .bundleDependencies(ext.getBundleDependencies())
+                .executable(ext.getExecutable())
                 .properties(ext.getProperties())
                 .properties(fromFile)
                 .properties(PropertiesUtil.filteredSystemProperties(ext.getProperties(), false))

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
@@ -31,6 +31,8 @@ public class SwarmExtension {
 
     private Boolean bundleDependencies = true;
 
+    private Boolean executable = false;
+
     private Properties properties = new Properties();
 
     private File propertiesFile;
@@ -67,6 +69,14 @@ public class SwarmExtension {
 
     public void setBundleDependencies(Boolean bundleDependencies) {
         this.bundleDependencies = bundleDependencies;
+    }
+
+    public Boolean getExecutable() {
+        return executable;
+    }
+
+    public void setExecutable(Boolean executable) {
+        this.executable = executable;
     }
 
     public File getPropertiesFile() {

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/gradle/SwarmExtension.java
@@ -33,6 +33,8 @@ public class SwarmExtension {
 
     private Boolean executable = false;
 
+    private File executableScript;
+
     private Properties properties = new Properties();
 
     private File propertiesFile;
@@ -77,6 +79,14 @@ public class SwarmExtension {
 
     public void setExecutable(Boolean executable) {
         this.executable = executable;
+    }
+
+    public File getExecutableScript() {
+        return executableScript;
+    }
+
+    public void setExecutableScript(File executableScript) {
+        this.executableScript = executableScript;
     }
 
     public File getPropertiesFile() {

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -47,6 +47,12 @@ public class PackageMojo extends AbstractSwarmMojo {
     @Parameter(alias = "bundleDependencies", defaultValue = "true")
     protected boolean bundleDependencies;
 
+    /**
+     * Make a fully executable jar for *nix machines by prepending a launch script to the jar.
+     */
+    @Parameter(alias = "executable", defaultValue = "false")
+    protected boolean executable;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         initProperties(false);
@@ -66,6 +72,7 @@ public class PackageMojo extends AbstractSwarmMojo {
                 .properties(this.properties)
                 .mainClass(this.mainClass)
                 .bundleDependencies(this.bundleDependencies)
+                .executable(executable)
                 .fractionDetectionMode(fractionDetectMode)
                 .artifactResolvingHelper(mavenArtifactResolvingHelper())
                 .logger(new BuildTool.SimpleLogger() {

--- a/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
+++ b/plugin/src/main/java/org/wildfly/swarm/plugin/maven/PackageMojo.java
@@ -53,6 +53,12 @@ public class PackageMojo extends AbstractSwarmMojo {
     @Parameter(alias = "executable", defaultValue = "false")
     protected boolean executable;
 
+    /**
+     * A custom script for *nix machines by prepending a launch script to the jar. Added only when executable = true
+     */
+    @Parameter(alias = "executableScript")
+    protected File executableScript;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         initProperties(false);
@@ -73,6 +79,7 @@ public class PackageMojo extends AbstractSwarmMojo {
                 .mainClass(this.mainClass)
                 .bundleDependencies(this.bundleDependencies)
                 .executable(executable)
+                .executableScript(executableScript)
                 .fractionDetectionMode(fractionDetectMode)
                 .artifactResolvingHelper(mavenArtifactResolvingHelper())
                 .logger(new BuildTool.SimpleLogger() {


### PR DESCRIPTION
Motivation: The reason for having executable jars lies on making it possible
to be easily started as Unix/Linux services using either init.d or systemd.

Result: The PackageMojo and PackageTask now declares an executable property that prepends a sh script and sets the JAR to be an executable.